### PR TITLE
Safe slashing

### DIFF
--- a/contracts/Errors.sol
+++ b/contracts/Errors.sol
@@ -22,6 +22,8 @@ error BaseTokenNotSet(address pyroToken);
 error OnlyReceiver(address receiver, address msgSender);
 error OnlyLoanOfficer(address officer, address msgSender);
 error UnsustainablePyroLoan(uint256 stake, uint256 minStake);
+error SlashPercentageTooHigh(uint256 slashPercentage);
+
 //LIQUIDITYRECEIVER
 error SnufferCapExpected(address expected, address actual);
 error OnlyContracts(address target);

--- a/contracts/facades/PyroTokenLike.sol
+++ b/contracts/facades/PyroTokenLike.sol
@@ -42,7 +42,8 @@ abstract contract PyroTokenLike is IERC20 {
     function setObligationFor(
         address borrower,
         uint256 baseTokenBorrowed,
-        uint256 pyroTokenStaked
+        uint256 pyroTokenStaked,
+        uint256 slashBasisPoints
     ) external virtual returns (bool);
 
      function calculateRedemptionFee(uint256 amount, address redeemer)

--- a/contracts/testing/SimpleLoanOfficer.sol
+++ b/contracts/testing/SimpleLoanOfficer.sol
@@ -8,13 +8,15 @@ contract SimpleLoanOfficer {
     function setObligationFor(
         address pyroToken,
         uint256 baseTokenBorrowed,
-        uint256 pyroTokenStaked
+        uint256 pyroTokenStaked,
+        uint slashBP
     ) external returns (bool) {
         return
             PyroTokenLike(pyroToken).setObligationFor(
                 msg.sender,
                 baseTokenBorrowed,
-                pyroTokenStaked
+                pyroTokenStaked,
+                slashBP
             );
     }
 }

--- a/test/arrange/pyroToken.ts
+++ b/test/arrange/pyroToken.ts
@@ -195,7 +195,7 @@ export async function t9Setup(
     .mint(secondPerson.address, CONSTANTS.TEN.mul(3));
 
   //BORROW
-  await SET.loanOfficer.setObligationFor(SET.PyroTokens.pyroRegular1.address,CONSTANTS.TEN,CONSTANTS.TEN)
+  await SET.loanOfficer.setObligationFor(SET.PyroTokens.pyroRegular1.address,CONSTANTS.TEN,CONSTANTS.TEN,0)
 }
 
 export async function t10Setup(
@@ -224,7 +224,7 @@ export async function t10Setup(
 
 
   //BORROW and stake 30 Pyro
-  await SET.loanOfficer.setObligationFor(SET.PyroTokens.pyroRegular1.address,CONSTANTS.TEN,CONSTANTS.TEN)
+  await SET.loanOfficer.setObligationFor(SET.PyroTokens.pyroRegular1.address,CONSTANTS.TEN,CONSTANTS.TEN,0)
 }
 
 
@@ -251,4 +251,37 @@ export async function t11Setup(
   await pyroToken
     .connect(secondPerson)
     .mint(secondPerson.address, CONSTANTS.TEN.mul(3));
+}
+
+export async function t12Setup(
+  SET: TestSet,
+  owner: any,
+  logger: any,
+  ...args: Array<any>
+) {
+  const pyroToken = SET.PyroTokens.pyroRegular1;
+  const baseToken = SET.BaseTokens.regularToken1;
+  const secondPerson = args[0] as SignerWithAddress;
+  //mint pyrotokens
+  await baseToken.approve(pyroToken.address, CONSTANTS.MAX);
+  await baseToken
+    .connect(secondPerson)
+    .approve(pyroToken.address, CONSTANTS.MAX);
+
+  //mint 30
+  await pyroToken.mint(owner.address, CONSTANTS.TEN);
+
+  await baseToken.connect(secondPerson).mint(CONSTANTS.HUNDRED);
+
+  await pyroToken
+    .connect(secondPerson)
+    .mint(secondPerson.address, CONSTANTS.TEN.mul(3));
+
+
+  //BORROW and stake 30 Pyro
+  await SET.loanOfficer.setObligationFor(
+    pyroToken.address,
+    CONSTANTS.TEN, //baseBorrow
+    CONSTANTS.TEN, //pyroStake
+    0)
 }


### PR DESCRIPTION
In the previous PR, the loan officer had no ability to directly slash staked user pyrotokens. 
The idea was that the loan officer should deposit all its clients' pyros under one name. This would protect the pyroToken from being put into an invalid or insolvent state by a buggy loan officer. The downside is higher gas consumption for every borrow and stake operation.

However, by adding a slash percentage parameter to setDebtObligations, insolvent liquidations can be implemented on a per end user basis at no increased risk to the system. The gas costs are consequently lower because of reduced indirection. Also the position of every borrower will be reflected on the pyrotoken contract, not the loan officer which maintains the necessary separation of concerns between state and logic. 
This last point might be the most important of all.